### PR TITLE
Ground the Juno articles in the codebase and clean up the prose

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,17 @@
       margin-bottom: 16px;
     }
 
+    .writing-item {
+      margin-bottom: 18px;
+    }
+
+    .writing-item .desc {
+      display: block;
+      color: var(--muted);
+      font-size: 0.9rem;
+      line-height: 1.55;
+    }
+
     .links {
       margin-top: 56px;
       display: flex;
@@ -120,12 +131,28 @@
     </p>
 
     <p>
-      One of my big projects during the break is planning my own wedding — so naturally, I built <a href="https://getjuno.tech/" target="_blank" rel="noopener">Juno</a>, an AI agent for wedding planning. Give it a shot if you have a wedding coming up — or <a href="juno/index.html">read about how I built it</a>.
+      One of my big projects during the break is planning my own wedding — so naturally, I built <a href="https://getjuno.tech/" target="_blank" rel="noopener">Juno</a>, an AI agent for wedding planning, solo in about a month. Give it a shot if you have a wedding coming up — or read about how I built it below.
     </p>
 
     <p>
       Feel free to reach out!
     </p>
+
+    <div class="section">
+      <div class="section-label">Writing</div>
+      <div class="writing-item">
+        <a href="juno/index.html">Juno: an AI wedding planner you can actually trust</a>
+        <span class="desc">The product case study — the design decisions and trust boundaries behind an AI agent that couples hand real work to, and what running my own wedding on it has taught me.</span>
+      </div>
+      <div class="writing-item">
+        <a href="juno/evals/index.html">Evals instead of vibes</a>
+        <span class="desc">Quality infrastructure for an agent product: evaluate the production code path, score deterministically first, diff against committed baselines, and grow test cases from production failures.</span>
+      </div>
+      <div class="writing-item">
+        <a href="juno/building/index.html">Building Juno solo, in a month, with AI coding agents</a>
+        <span class="desc">The spec-driven workflow behind the build — where it broke down, why CI was the game changer, and what agent teams taught me about product work.</span>
+      </div>
+    </div>
 
     <div class="links">
       <a href="ceramics/index.html">Ceramics</a>

--- a/juno/building/index.html
+++ b/juno/building/index.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Building Juno solo, in a month, with AI coding agents | Jaeyoon Jung</title>
+  <meta name="description" content="The spec-driven workflow behind Juno: how I shipped a production AI-agent product solo in about a month with Claude Code and Codex — what worked, where the workflow broke down, and why CI was the game changer." />
+  <style>
+    :root {
+      --text: #1a1a1a;
+      --muted: #666;
+      --link: #1a1a1a;
+      --bg: #fff;
+      --border: #e4e0d8;
+      --card: #faf8f4;
+      --max-width: 680px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 17px;
+      line-height: 1.7;
+      color: var(--text);
+      background: var(--bg);
+      padding: 60px 24px 100px;
+    }
+
+    main {
+      max-width: var(--max-width);
+      margin: 0 auto;
+    }
+
+    .back {
+      display: inline-block;
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin-bottom: 40px;
+    }
+
+    h1 {
+      font-size: 1.9rem;
+      font-weight: 700;
+      letter-spacing: -0.4px;
+      line-height: 1.25;
+      margin-bottom: 10px;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 8px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-bottom: 48px;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.2px;
+      margin: 56px 0 16px;
+    }
+
+    p { margin-bottom: 20px; }
+
+    ul, ol {
+      margin: 0 0 20px 1.2em;
+    }
+
+    li { margin-bottom: 10px; }
+
+    a {
+      color: var(--link);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    a:hover { opacity: 0.6; }
+
+    strong { font-weight: 650; }
+
+    code {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.86em;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      white-space: nowrap;
+    }
+
+    .flow {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      margin: 24px 0 28px;
+      font-size: 0.85rem;
+    }
+
+    .flow .step {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 7px 12px;
+      line-height: 1.4;
+      white-space: nowrap;
+    }
+
+    .flow .arrow {
+      color: var(--muted);
+      flex-shrink: 0;
+    }
+
+    .footer-links {
+      margin-top: 64px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      font-size: 0.95rem;
+    }
+
+    .footer-links a { color: var(--muted); }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --text: #e8e8e8;
+        --muted: #888;
+        --link: #e8e8e8;
+        --bg: #111;
+        --border: #2c2c2c;
+        --card: #1a1a1a;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <a class="back" href="../">← Juno case study</a>
+
+    <h1>Building Juno solo, in a month, with AI coding agents</h1>
+    <p class="subtitle">The spec-driven workflow that let one person ship a production agent product — what worked, where it broke down, and why CI turned out to be the real game changer.</p>
+    <p class="meta">2026 · Part of the <a href="../">Juno</a> series</p>
+
+    <p>
+      <a href="../">Juno</a> — an AI wedding-planning studio with a full workspace, an email
+      ingestion pipeline, and an agent with her own inbox — was built by one person in about a
+      month, alongside planning the actual wedding it's used for. That was only possible because
+      the build itself was AI-native: most of the code was written by AI coding agents, and my job
+      looked a lot more like product management than typing — writing specs, defining invariants,
+      reviewing diffs, and maintaining the context that keeps agent work coherent.
+    </p>
+
+    <h2>The workflow</h2>
+    <p>
+      Every feature runs through the same pipeline, using both Claude Code and Codex:
+    </p>
+    <div class="flow">
+      <span class="step">Roadmap feature</span>
+      <span class="arrow">→</span>
+      <span class="step">Written spec</span>
+      <span class="arrow">→</span>
+      <span class="step">Implementation plan</span>
+      <span class="arrow">→</span>
+      <span class="step">Task list</span>
+      <span class="arrow">→</span>
+      <span class="step">Implementation</span>
+    </div>
+    <p>
+      The connective tissue is an <strong>agents-facing architecture document</strong>: a living
+      file that records the repo's conventions, invariants, and design decisions — which mutations
+      exist, what the agent is and isn't allowed to touch, how timezones are stored, what the
+      review-queue state machine allows. Every coding session starts grounded in it, which is what
+      keeps session #40 consistent with session #3. Maintaining that document is the highest-leverage
+      writing I did on the project: it's the difference between an agent that extends your
+      architecture and one that reinvents it slightly wrong each time.
+    </p>
+
+    <h2>Where the workflow broke down</h2>
+    <p>
+      The pipeline's failure mode wasn't quality — it was <strong>ceremony</strong>. My initial
+      definition of a "roadmap feature" was too loose, so the workflow would take a small change and
+      dutifully inflate it into a full spec, implementation plan, and task list. The output quality
+      was genuinely good; the token bill was not. A one-hour tweak would burn the process overhead
+      of a one-week feature.
+    </p>
+    <p>
+      The fix was tuning the entry criteria: deciding what deserves the full spec-driven treatment
+      and what should just be a direct, lightweight edit. That judgment — matching process weight to
+      change size — turns out to be the same skill as running a human team, where making everyone
+      write a PRD for a copy change kills velocity. Agent teams don't push back on ceremony the way
+      humans do; they'll happily generate all of it. The discipline has to come from you.
+    </p>
+
+    <h2>CI was the game changer</h2>
+    <p>
+      The single highest-impact investment was boring: continuous integration. Every PR runs four
+      quality gates — lint, typecheck, unit tests, production build — plus a 36-test Playwright e2e
+      suite across 6 spec files, running against real auth and row-level security with deterministic
+      mock model responses. Once that wall existed, bugs largely stopped reaching <code>main</code>.
+    </p>
+    <p>
+      This matters more with agent-written code, not less. Agents produce plausible code fast, and
+      review attention is the scarce resource — so the machine has to catch the mechanical failures
+      before a human ever looks. CI is what converts "an agent wrote a lot of code quickly" from a
+      liability into velocity. (Model-quality regressions are a different failure class with a
+      different harness — that's the <a href="../evals/">evals article</a>.)
+    </p>
+
+    <h2>Invariants as code, not vigilance</h2>
+    <p>
+      With agents doing most of the writing, anything you're not willing to re-review on every diff
+      has to be enforced mechanically:
+    </p>
+    <ul>
+      <li>
+        <strong>One mutation surface.</strong> The workspace has 70 server actions (Zod-validated,
+        audit-logged); 57 of them are also registered as agent tools with schemas derived from the
+        same Zod definitions. There's no separate "agent API" to drift out of sync — and the gap of
+        13 is deliberate: sends, uploads, invites, and review-queue approvals are user-only.
+      </li>
+      <li>
+        <strong>The allowlist is pinned by a unit test.</strong> June must never gain send-email or
+        payment authority, so that boundary isn't a convention in a doc — it's a test that fails if
+        a refactor (human or agent) ever changes the tool registry. Guardrails you'd normally
+        enforce through code review become code themselves.
+      </li>
+    </ul>
+
+    <h2>What this taught me</h2>
+    <p>
+      A month of this settled a question I had about what happens to product work when agents write
+      the code: the PM skillset doesn't get automated away — it becomes the bottleneck skill.
+      Everything that made the agents effective was product work: a crisp spec, an explicit
+      invariant, a well-maintained architecture doc, a decision about how much process a change
+      deserves. Everything that went wrong traced back to a place where I'd been vague. Building
+      with agent teams is a compressed, high-feedback version of the job I already had — you find
+      out within hours, not quarters, whether your spec was actually clear.
+    </p>
+
+    <div class="footer-links">
+      <a href="../">Juno case study</a>
+      <a href="../evals/">Evals instead of vibes</a>
+      <a href="https://getjuno.tech/" target="_blank" rel="noopener">Try Juno</a>
+      <a href="/">About me</a>
+      <a href="mailto:jaeyoonjung95@gmail.com">Email</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/juno/building/index.html
+++ b/juno/building/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Building Juno solo, in a month, with AI coding agents | Jaeyoon Jung</title>
-  <meta name="description" content="The spec-driven workflow behind Juno: how I shipped a production AI-agent product solo in about a month with Claude Code and Codex — what worked, where the workflow broke down, and why CI was the game changer." />
+  <meta name="description" content="The spec-driven workflow behind Juno: how I shipped a production AI-agent product solo in about a month with Claude Code and Codex, what worked, where the workflow broke down, and why CI was the game changer." />
   <style>
     :root {
       --text: #1a1a1a;
@@ -150,55 +150,80 @@
     <a class="back" href="../">← Juno case study</a>
 
     <h1>Building Juno solo, in a month, with AI coding agents</h1>
-    <p class="subtitle">The spec-driven workflow that let one person ship a production agent product — what worked, where it broke down, and why CI turned out to be the real game changer.</p>
+    <p class="subtitle">The spec-driven workflow that let one person ship a production agent product: what worked, where it broke down, and why CI turned out to be the real game changer.</p>
     <p class="meta">2026 · Part of the <a href="../">Juno</a> series</p>
 
     <p>
-      <a href="../">Juno</a> — an AI wedding-planning studio with a full workspace, an email
-      ingestion pipeline, and an agent with her own inbox — was built by one person in about a
+      <a href="../">Juno</a> is an AI wedding-planning studio with a full workspace, an email
+      ingestion pipeline, and an agent with her own inbox. I built it solo in about a
       month, alongside planning the actual wedding it's used for. That was only possible because
       the build itself was AI-native: most of the code was written by AI coding agents, and my job
-      looked a lot more like product management than typing — writing specs, defining invariants,
+      looked a lot more like product management than typing. I spent it writing specs, defining invariants,
       reviewing diffs, and maintaining the context that keeps agent work coherent.
     </p>
 
     <h2>The workflow</h2>
     <p>
-      Every feature runs through the same pipeline, using both Claude Code and Codex:
+      Every feature runs through the same pipeline, using both Claude Code and Codex. I encoded
+      it as a set of skills, one per phase, so the steps and their gates stay identical from one
+      feature to the next:
     </p>
     <div class="flow">
-      <span class="step">Roadmap feature</span>
+      <span class="step">Roadmap item</span>
       <span class="arrow">→</span>
-      <span class="step">Written spec</span>
+      <span class="step">spec.md</span>
       <span class="arrow">→</span>
-      <span class="step">Implementation plan</span>
+      <span class="step">plan.md</span>
       <span class="arrow">→</span>
-      <span class="step">Task list</span>
+      <span class="step">tasks.md</span>
       <span class="arrow">→</span>
       <span class="step">Implementation</span>
+      <span class="arrow">→</span>
+      <span class="step">PR</span>
     </div>
     <p>
-      The connective tissue is an <strong>agents-facing architecture document</strong>: a living
-      file that records the repo's conventions, invariants, and design decisions — which mutations
-      exist, what the agent is and isn't allowed to touch, how timezones are stored, what the
-      review-queue state machine allows. Every coding session starts grounded in it, which is what
-      keeps session #40 consistent with session #3. Maintaining that document is the highest-leverage
-      writing I did on the project: it's the difference between an agent that extends your
-      architecture and one that reinvents it slightly wrong each time.
+      A roadmap item becomes three separate artifacts before any code gets written.
+      <code>spec.md</code> owns the decisions: user-facing behavior, scope boundary, data model,
+      dependencies, and testable success criteria. <code>plan.md</code> owns sequencing: components,
+      their order, and the risks. <code>tasks.md</code> owns implementation: a checklist a coding
+      session can execute one thin slice at a time. Each artifact is a gate. The workflow does not
+      advance to the next until I've approved the current one, and a repair pass blocks the handoff
+      while any open decision is still unanswered. Only then does implementation run, and it stops
+      at an open PR rather than merging itself.
+    </p>
+    <p>
+      The shape of the spec owes a lot to Addy Osmani's
+      <a href="https://addyosmani.com/blog/good-spec/" target="_blank" rel="noopener">How to write a
+      good spec for AI agents</a>, which is where I picked up most of what I know here: start from a
+      high-level vision and let the agent expand it, structure the spec like a PRD, break the work
+      into modular tasks, and write explicit "always / ask first / never" boundaries into the spec
+      so the agent has constraints to check itself against.
+    </p>
+    <p>
+      The connective tissue is an <strong>agents-facing architecture document</strong> (the repo's
+      <code>AGENTS.md</code> and <code>CLAUDE.md</code>): a living file that records the repo's
+      conventions, invariants, and design decisions. Which mutations exist, what the agent is and
+      isn't allowed to touch, how timezones are stored, what the review-queue state machine allows.
+      Every coding session starts grounded in it, which is what keeps session #40 consistent with
+      session #3. Maintaining that document is the highest-leverage writing I did on the project:
+      it's the difference between an agent that extends your architecture and one that reinvents it
+      slightly wrong each time.
     </p>
 
     <h2>Where the workflow broke down</h2>
     <p>
-      The pipeline's failure mode wasn't quality — it was <strong>ceremony</strong>. My initial
-      definition of a "roadmap feature" was too loose, so the workflow would take a small change and
-      dutifully inflate it into a full spec, implementation plan, and task list. The output quality
+      The pipeline's failure mode wasn't quality. It was <strong>ceremony</strong>. My initial
+      definition of a "roadmap item" was too loose, so the workflow would take a small change and
+      dutifully inflate it into a full spec, plan, and task list. The output quality
       was genuinely good; the token bill was not. A one-hour tweak would burn the process overhead
       of a one-week feature.
     </p>
     <p>
       The fix was tuning the entry criteria: deciding what deserves the full spec-driven treatment
-      and what should just be a direct, lightweight edit. That judgment — matching process weight to
-      change size — turns out to be the same skill as running a human team, where making everyone
+      and what should just be a direct, lightweight edit. I set a rough floor of three to eight
+      implementation tasks for anything that goes through the full pipeline; smaller work gets
+      grouped with adjacent changes or done as a direct edit. That judgment, matching process weight
+      to change size, turns out to be the same skill as running a human team, where making everyone
       write a PRD for a copy change kills velocity. Agent teams don't push back on ceremony the way
       humans do; they'll happily generate all of it. The discipline has to come from you.
     </p>
@@ -206,16 +231,16 @@
     <h2>CI was the game changer</h2>
     <p>
       The single highest-impact investment was boring: continuous integration. Every PR runs four
-      quality gates — lint, typecheck, unit tests, production build — plus a 36-test Playwright e2e
+      quality gates (lint, typecheck, unit tests, production build) plus a 36-test Playwright e2e
       suite across 6 spec files, running against real auth and row-level security with deterministic
       mock model responses. Once that wall existed, bugs largely stopped reaching <code>main</code>.
     </p>
     <p>
       This matters more with agent-written code, not less. Agents produce plausible code fast, and
-      review attention is the scarce resource — so the machine has to catch the mechanical failures
+      review attention is the scarce resource, so the machine has to catch the mechanical failures
       before a human ever looks. CI is what converts "an agent wrote a lot of code quickly" from a
       liability into velocity. (Model-quality regressions are a different failure class with a
-      different harness — that's the <a href="../evals/">evals article</a>.)
+      different harness. That's the <a href="../evals/">evals article</a>.)
     </p>
 
     <h2>Invariants as code, not vigilance</h2>
@@ -227,12 +252,12 @@
       <li>
         <strong>One mutation surface.</strong> The workspace has 70 server actions (Zod-validated,
         audit-logged); 57 of them are also registered as agent tools with schemas derived from the
-        same Zod definitions. There's no separate "agent API" to drift out of sync — and the gap of
+        same Zod definitions. There's no separate "agent API" to drift out of sync, and the gap of
         13 is deliberate: sends, uploads, invites, and review-queue approvals are user-only.
       </li>
       <li>
         <strong>The allowlist is pinned by a unit test.</strong> June must never gain send-email or
-        payment authority, so that boundary isn't a convention in a doc — it's a test that fails if
+        payment authority, so that boundary isn't a convention in a doc. It's a test that fails if
         a refactor (human or agent) ever changes the tool registry. Guardrails you'd normally
         enforce through code review become code themselves.
       </li>
@@ -241,11 +266,11 @@
     <h2>What this taught me</h2>
     <p>
       A month of this settled a question I had about what happens to product work when agents write
-      the code: the PM skillset doesn't get automated away — it becomes the bottleneck skill.
+      the code: the PM skillset doesn't get automated away. It becomes the bottleneck skill.
       Everything that made the agents effective was product work: a crisp spec, an explicit
       invariant, a well-maintained architecture doc, a decision about how much process a change
       deserves. Everything that went wrong traced back to a place where I'd been vague. Building
-      with agent teams is a compressed, high-feedback version of the job I already had — you find
+      with agent teams is a compressed, high-feedback version of the job I already had. You find
       out within hours, not quarters, whether your spec was actually clear.
     </p>
 

--- a/juno/evals/index.html
+++ b/juno/evals/index.html
@@ -153,51 +153,65 @@
     <a class="back" href="../">← Juno case study</a>
 
     <h1>Evals instead of vibes</h1>
-    <p class="subtitle">The quality infrastructure behind a solo-built AI agent product — five design decisions I'd defend hardest, and the one judgment call no eval suite written in advance could capture.</p>
+    <p class="subtitle">The quality infrastructure behind a solo-built AI agent product: five design decisions I'd defend hardest, and the one judgment call no eval suite written in advance could capture.</p>
     <p class="meta">2026 · Part of the <a href="../">Juno</a> series</p>
 
     <p>
       <a href="../">Juno</a> is an AI wedding-planning studio with two LLM surfaces: an ingestion
-      pipeline that turns vendor email and documents into structured, reviewable changes, and June —
+      pipeline that turns vendor email and documents into structured, reviewable changes, and June,
       an agent that reads the whole workspace, answers questions, drafts outreach, and proposes
       changes. An agent product lives or dies on quality you can't see in a demo: does the pipeline
       catch the payment schedule buried in an email? Does June answer from the workspace's actual
       data, or does she make something up?
     </p>
     <p>
-      Early on I was judging prompt changes by re-running a few scenarios and eyeballing the output —
+      Early on I was judging prompt changes by re-running a few scenarios and eyeballing the output,
       which stops working the moment you have more than a handful of behaviors to protect. So both
       surfaces got eval harnesses, and the design decisions behind them are some of the ones I'd
       defend hardest in any review.
     </p>
 
     <div class="stats">
-      <span class="stat"><strong>22</strong><small>golden fixtures, ingestion harness</small></span>
+      <span class="stat"><strong>22</strong><small>golden fixtures (11 extract + 11 reconcile), ingestion harness</small></span>
       <span class="stat"><strong>21</strong><small>scenario fixtures across 7 suites, agent harness</small></span>
-      <span class="stat"><strong>36</strong><small>e2e tests across 6 spec files, in CI — not evals</small></span>
+      <span class="stat"><strong>36</strong><small>e2e tests across 6 spec files, in CI, not evals</small></span>
     </div>
 
     <h2>1. Evaluate the production code path, not a copy of it</h2>
     <p>
-      The harnesses run the real extraction and reconcile functions, and the real agent loop — with
-      database-backed tools swapped for fixture-backed ones that serve identical schemas from a
-      shared workspace snapshot. The tradeoff is more plumbing up front. The alternative — a
-      simplified "eval version" of the pipeline — silently drifts from what production actually
-      does, and then your scores measure nothing. When a metric moves in this setup, it moved
-      because the production behavior moved.
+      The ingestion harness imports and runs the real extract and reconcile functions plus the
+      real deterministic filter that backstops them. The agent harness drives the real agent loop,
+      the same function production calls, with the database-backed read tools swapped for
+      fixture-backed ones that serve the exact same tool names and schemas from a shared workspace
+      snapshot. No Postgres, no storage, no live model writes: approved workspace changes are
+      recorded for scoring, never executed.
+    </p>
+    <p>
+      Two seams the agent harness can't import directly, because they live in a server-only file, it
+      reimplements and then pins with a unit test that fails if the production contract drifts: the
+      rule that carries a previous run's transcript into a resume, and the couple-facing resolution
+      copy. The tradeoff for all of this is more plumbing up front. The alternative, a simplified
+      "eval version" of the pipeline, silently drifts from what production actually does, and then
+      your scores measure nothing. When a metric moves in this setup, it moved because the
+      production behavior moved.
     </p>
 
     <h2>2. Deterministic scoring first; an LLM judge only where determinism fails</h2>
     <p>
       Most of what matters is checkable in plain code: did the right entities come out, with the
-      right key fields, the right statuses, the right tool calls made — and the forbidden ones
-      <em>not</em> made. An LLM judge is reserved for the genuinely fuzzy residue: is "Confirm final
-      headcount with caterer" the same task as "caterer needs guest count"? Is an answer actually
-      supported by what the tools returned?
+      right key fields, the right statuses, the right tool calls made, and the forbidden ones
+      <em>not</em> made. That last part carries the safety weight. The agent scorer pins that June
+      never calls an unmounted tool, never returns a tool error, and never trips a global deny-list
+      on sending or paying. An LLM judge is reserved for the genuinely fuzzy residue: is "Confirm
+      final headcount with caterer" the same task as "caterer needs guest count"? Is an answer
+      actually grounded in what the tools returned? Does a draft sound like June?
     </p>
     <p>
-      Judges are convenient, so the temptation is to let one grade everything — but a judge is
-      itself a model that drifts and has blind spots. Keeping its scope narrow keeps the scores
+      Judges are convenient, so the temptation is to let one grade everything, but a judge is
+      itself a model that drifts and has blind spots. So its scope is deliberately narrow: the
+      ingestion judge only settles free-text field equivalence and pairings the fuzzy matcher
+      couldn't decide, never re-scoring what determinism already scored, and its results are
+      skippable with a flag. Keeping the judge narrow keeps the scores
       auditable: when a metric moves, I can almost always point to the exact deterministic check
       that moved it.
     </p>
@@ -205,51 +219,57 @@
     <h2>3. A committed baseline instead of pass/fail thresholds</h2>
     <p>
       Absolute thresholds ("extraction accuracy must exceed 90%") invite gaming and hide slow decay.
-      Instead, every eval run diffs against a baseline file checked into the repo, and updating that
-      baseline is an explicit, reviewable commit. A prompt change that trades recall on contracts
-      for precision on tasks shows up as exactly that — a diff a reviewer can reason about, not a
-      green checkmark.
+      Instead, each harness diffs every run against a committed baseline file (one for ingestion,
+      one for the agent), and updating that baseline is an explicit, reviewable commit behind a
+      dedicated flag that refuses to write if any fixture errored out. A prompt change that trades
+      recall on contracts for precision on tasks shows up as exactly that, a diff a reviewer can
+      reason about, not a green checkmark.
     </p>
 
     <h2>4. Evals are not CI</h2>
     <p>
       Eval runs call the real model APIs: they cost money and are nondeterministic, which makes them
-      terrible PR gates. So the two systems are deliberately separate. CI exercises every
-      user-facing flow end-to-end — 36 Playwright tests across 6 spec files, against real auth and
-      row-level security, with deterministic mock model responses. CI answers "does the machinery
-      work?" Evals run on demand with repeat trials to average out variance, and answer "is the
-      model's judgment good?" Conflating the two gets you flaky CI and eval suites nobody runs.
+      terrible PR gates. So the two systems are deliberately separate. The eval scripts live outside
+      <code>npm test</code> and never run in CI. CI exercises every user-facing flow end-to-end: 36
+      Playwright tests across 6 spec files, against real auth and row-level security, with
+      deterministic mock model responses. CI answers "does the machinery work?" Evals run on demand
+      with repeat trials to average out variance, and answer "is the model's judgment good?"
+      Conflating the two gets you flaky CI and eval suites nobody runs.
     </p>
 
-    <h2>5. Test cases come from production failures — carefully</h2>
+    <h2>5. Test cases come from production failures, carefully</h2>
     <p>
-      When June gets something wrong, I flag the run in the UI, which snapshots everything the
-      failing run saw: the conversation, and the workspace state <em>at that moment</em>, so the
-      case still reproduces after the live data moves on. Two guardrails I added after thinking
-      about how this could go wrong:
+      When June gets something wrong, a privileged flag button in the UI snapshots everything the
+      failing run saw into a locked-down table: the conversation, the run transcript, and the
+      workspace state <em>at that moment</em>, so the case still reproduces after the live data
+      moves on. A separate export command reshapes open flags into <em>draft</em> fixtures that sit
+      in a drafts folder, outside the validated fixture directories the tests actually load. Nothing
+      becomes a real test case automatically. Two guardrails enforce that:
     </p>
     <ul>
       <li>
-        <strong>The flagged output never becomes the expected answer.</strong> It's preserved as
-        reference, but a human writes what <em>should</em> have happened. Otherwise the suite would
-        enshrine the exact failure it was meant to catch.
+        <strong>The flagged output never becomes the expected answer.</strong> The draft's expected
+        fields are seeded with placeholders, not the model's output; the flagged output is preserved
+        separately, labeled as the wrong answer, and a human writes what <em>should</em> have
+        happened. Otherwise the suite would enshrine the exact failure it was meant to catch.
       </li>
       <li>
         <strong>Every case passes through human review and redaction before promotion.</strong>
-        Production data contains real names, real vendors, and real money.
+        Production data contains real names, real vendors, and real money, so a draft is promoted
+        out of the drafts folder by hand, never on export.
       </li>
     </ul>
 
     <h2>The case that made the flag loop essential</h2>
     <p>
-      I expected the hard eval problems to be extractive — dates, amounts, payment schedules. They
-      weren't. The hardest judgment June has to make is <strong>editorial</strong>: of the hundred
+      I expected the hard eval problems to be extractive: dates, amounts, payment schedules. They
+      weren't. The hardest judgment June has to make is <strong>editorial</strong>. Of the hundred
       small facts flowing through vendor threads, which ones are <em>decisions worth logging</em>
       and making visible to the couple? "We're going with the family-style menu" clearly is.
       "The florist prefers Tuesday deliveries" clearly isn't. Most of real life sits in between.
     </p>
     <p>
-      I tried to write that boundary down ahead of time and couldn't — and an eval suite authored in
+      I tried to write that boundary down ahead of time and couldn't, and an eval suite authored in
       a vacuum just encodes the author's guess. What actually works is running the product on my own
       wedding and letting the disagreements become data: every time June logs noise or misses a real
       decision, the flag pipeline turns that moment into a fixture with a human-written expected

--- a/juno/evals/index.html
+++ b/juno/evals/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Evals instead of vibes | Jaeyoon Jung</title>
+  <meta name="description" content="How I built eval harnesses for an AI-agent product: evaluate the production code path, score deterministically first, diff against committed baselines, keep evals out of CI, and grow test cases from production failures." />
+  <style>
+    :root {
+      --text: #1a1a1a;
+      --muted: #666;
+      --link: #1a1a1a;
+      --bg: #fff;
+      --border: #e4e0d8;
+      --card: #faf8f4;
+      --max-width: 680px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 17px;
+      line-height: 1.7;
+      color: var(--text);
+      background: var(--bg);
+      padding: 60px 24px 100px;
+    }
+
+    main {
+      max-width: var(--max-width);
+      margin: 0 auto;
+    }
+
+    .back {
+      display: inline-block;
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin-bottom: 40px;
+    }
+
+    h1 {
+      font-size: 1.9rem;
+      font-weight: 700;
+      letter-spacing: -0.4px;
+      line-height: 1.25;
+      margin-bottom: 10px;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 8px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-bottom: 48px;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.2px;
+      margin: 56px 0 16px;
+    }
+
+    p { margin-bottom: 20px; }
+
+    ul, ol {
+      margin: 0 0 20px 1.2em;
+    }
+
+    li { margin-bottom: 10px; }
+
+    a {
+      color: var(--link);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+
+    a:hover { opacity: 0.6; }
+
+    strong { font-weight: 650; }
+
+    code {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.86em;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      white-space: nowrap;
+    }
+
+    .stats {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 24px 0 28px;
+      font-size: 0.85rem;
+    }
+
+    .stats .stat {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 10px 14px;
+      line-height: 1.4;
+    }
+
+    .stats .stat strong {
+      display: block;
+      font-size: 1.1rem;
+    }
+
+    .stats .stat small {
+      color: var(--muted);
+      font-size: 0.78rem;
+    }
+
+    .footer-links {
+      margin-top: 64px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+      font-size: 0.95rem;
+    }
+
+    .footer-links a { color: var(--muted); }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --text: #e8e8e8;
+        --muted: #888;
+        --link: #e8e8e8;
+        --bg: #111;
+        --border: #2c2c2c;
+        --card: #1a1a1a;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <a class="back" href="../">← Juno case study</a>
+
+    <h1>Evals instead of vibes</h1>
+    <p class="subtitle">The quality infrastructure behind a solo-built AI agent product — five design decisions I'd defend hardest, and the one judgment call no eval suite written in advance could capture.</p>
+    <p class="meta">2026 · Part of the <a href="../">Juno</a> series</p>
+
+    <p>
+      <a href="../">Juno</a> is an AI wedding-planning studio with two LLM surfaces: an ingestion
+      pipeline that turns vendor email and documents into structured, reviewable changes, and June —
+      an agent that reads the whole workspace, answers questions, drafts outreach, and proposes
+      changes. An agent product lives or dies on quality you can't see in a demo: does the pipeline
+      catch the payment schedule buried in an email? Does June answer from the workspace's actual
+      data, or does she make something up?
+    </p>
+    <p>
+      Early on I was judging prompt changes by re-running a few scenarios and eyeballing the output —
+      which stops working the moment you have more than a handful of behaviors to protect. So both
+      surfaces got eval harnesses, and the design decisions behind them are some of the ones I'd
+      defend hardest in any review.
+    </p>
+
+    <div class="stats">
+      <span class="stat"><strong>22</strong><small>golden fixtures, ingestion harness</small></span>
+      <span class="stat"><strong>21</strong><small>scenario fixtures across 7 suites, agent harness</small></span>
+      <span class="stat"><strong>36</strong><small>e2e tests across 6 spec files, in CI — not evals</small></span>
+    </div>
+
+    <h2>1. Evaluate the production code path, not a copy of it</h2>
+    <p>
+      The harnesses run the real extraction and reconcile functions, and the real agent loop — with
+      database-backed tools swapped for fixture-backed ones that serve identical schemas from a
+      shared workspace snapshot. The tradeoff is more plumbing up front. The alternative — a
+      simplified "eval version" of the pipeline — silently drifts from what production actually
+      does, and then your scores measure nothing. When a metric moves in this setup, it moved
+      because the production behavior moved.
+    </p>
+
+    <h2>2. Deterministic scoring first; an LLM judge only where determinism fails</h2>
+    <p>
+      Most of what matters is checkable in plain code: did the right entities come out, with the
+      right key fields, the right statuses, the right tool calls made — and the forbidden ones
+      <em>not</em> made. An LLM judge is reserved for the genuinely fuzzy residue: is "Confirm final
+      headcount with caterer" the same task as "caterer needs guest count"? Is an answer actually
+      supported by what the tools returned?
+    </p>
+    <p>
+      Judges are convenient, so the temptation is to let one grade everything — but a judge is
+      itself a model that drifts and has blind spots. Keeping its scope narrow keeps the scores
+      auditable: when a metric moves, I can almost always point to the exact deterministic check
+      that moved it.
+    </p>
+
+    <h2>3. A committed baseline instead of pass/fail thresholds</h2>
+    <p>
+      Absolute thresholds ("extraction accuracy must exceed 90%") invite gaming and hide slow decay.
+      Instead, every eval run diffs against a baseline file checked into the repo, and updating that
+      baseline is an explicit, reviewable commit. A prompt change that trades recall on contracts
+      for precision on tasks shows up as exactly that — a diff a reviewer can reason about, not a
+      green checkmark.
+    </p>
+
+    <h2>4. Evals are not CI</h2>
+    <p>
+      Eval runs call the real model APIs: they cost money and are nondeterministic, which makes them
+      terrible PR gates. So the two systems are deliberately separate. CI exercises every
+      user-facing flow end-to-end — 36 Playwright tests across 6 spec files, against real auth and
+      row-level security, with deterministic mock model responses. CI answers "does the machinery
+      work?" Evals run on demand with repeat trials to average out variance, and answer "is the
+      model's judgment good?" Conflating the two gets you flaky CI and eval suites nobody runs.
+    </p>
+
+    <h2>5. Test cases come from production failures — carefully</h2>
+    <p>
+      When June gets something wrong, I flag the run in the UI, which snapshots everything the
+      failing run saw: the conversation, and the workspace state <em>at that moment</em>, so the
+      case still reproduces after the live data moves on. Two guardrails I added after thinking
+      about how this could go wrong:
+    </p>
+    <ul>
+      <li>
+        <strong>The flagged output never becomes the expected answer.</strong> It's preserved as
+        reference, but a human writes what <em>should</em> have happened. Otherwise the suite would
+        enshrine the exact failure it was meant to catch.
+      </li>
+      <li>
+        <strong>Every case passes through human review and redaction before promotion.</strong>
+        Production data contains real names, real vendors, and real money.
+      </li>
+    </ul>
+
+    <h2>The case that made the flag loop essential</h2>
+    <p>
+      I expected the hard eval problems to be extractive — dates, amounts, payment schedules. They
+      weren't. The hardest judgment June has to make is <strong>editorial</strong>: of the hundred
+      small facts flowing through vendor threads, which ones are <em>decisions worth logging</em>
+      and making visible to the couple? "We're going with the family-style menu" clearly is.
+      "The florist prefers Tuesday deliveries" clearly isn't. Most of real life sits in between.
+    </p>
+    <p>
+      I tried to write that boundary down ahead of time and couldn't — and an eval suite authored in
+      a vacuum just encodes the author's guess. What actually works is running the product on my own
+      wedding and letting the disagreements become data: every time June logs noise or misses a real
+      decision, the flag pipeline turns that moment into a fixture with a human-written expected
+      answer. The eval suite isn't a spec I wrote once; it's an accumulating record of every place
+      my judgment and the model's diverged. For an agent product, I've come to think that's what an
+      eval suite <em>is</em>.
+    </p>
+
+    <div class="footer-links">
+      <a href="../">Juno case study</a>
+      <a href="../building/">Building Juno with AI coding agents</a>
+      <a href="https://getjuno.tech/" target="_blank" rel="noopener">Try Juno</a>
+      <a href="/">About me</a>
+      <a href="mailto:jaeyoonjung95@gmail.com">Email</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/juno/index.html
+++ b/juno/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Juno — an AI wedding planner | Jaeyoon Jung</title>
-  <meta name="description" content="How I built Juno, an AI-agent wedding planning studio, solo in about a month — and now run my own wedding on it. A case study in the trust boundaries that make an AI agent safe to use." />
+  <title>Juno: an AI wedding planner | Jaeyoon Jung</title>
+  <meta name="description" content="How I built Juno, an AI-agent wedding planning studio, solo in about a month, and now run my own wedding on it. A case study in the trust boundaries that make an AI agent safe to use." />
   <style>
     :root {
       --text: #1a1a1a;
@@ -206,7 +206,7 @@
     <a class="back" href="/">← Jaeyoon Jung</a>
 
     <h1>Juno: an AI wedding planner you can actually trust</h1>
-    <p class="subtitle">An AI-agent product I built solo in about a month — and now use to run my own wedding. A case study in designing the trust boundaries that make an agent safe to hand real work to.</p>
+    <p class="subtitle">An AI-agent product I built solo in about a month, and now use to run my own wedding. A case study in designing the trust boundaries that make an agent safe to hand real work to.</p>
     <p class="meta">2026 · <a href="https://getjuno.tech/" target="_blank" rel="noopener">getjuno.tech</a> · Next.js, Postgres, Claude</p>
     <p class="series">Deep dives: <a href="evals/">Evals instead of vibes</a> · <a href="building/">Building Juno with AI coding agents</a></p>
 
@@ -214,23 +214,23 @@
       While planning my own wedding, I kept hitting the same three problems every couple hits:
       there's <strong>no source of truth</strong> (decisions live across email threads, calls, contracts, and chat),
       the <strong>project-management overhead</strong> is enormous, and
-      <strong>you've never done this before</strong> — you plan a wedding exactly once, with no way to know if you've covered everything.
+      <strong>you've never done this before</strong> (you plan a wedding exactly once, with no way to know if you've covered everything).
     </p>
     <p>
-      Juno is my answer. Two names, one letter apart, so let me be precise:
-      <strong>Juno</strong> is the product — a private planning studio for one couple.
-      <strong>June</strong> is the planner who works inside it — an agent with her own inbox, her own
+      Juno is my answer. Two names, one letter apart, so let me be precise.
+      <strong>Juno</strong> is the product, a private planning studio for one couple.
+      <strong>June</strong> is the planner who works inside it: an agent with her own inbox, her own
       voice, and deliberately limited powers. You forward vendor emails to June, upload contracts and
       proposals, and ask her to handle things. She reads everything, keeps the workspace current, and
-      drafts outreach — but <em>every</em> change to your plan passes through your explicit approval.
+      drafts outreach, but <em>every</em> change to your plan passes through your explicit approval.
     </p>
     <p>
-      The wedge is specific, because I lived it. We locked in the big, obvious vendor decisions —
-      venue, caterer, photographer, florals — ourselves. At that point, hiring a human planner for
+      The wedge is specific, because I lived it. We locked in the big, obvious vendor decisions
+      (venue, caterer, photographer, florals) ourselves. At that point, hiring a human planner for
       thousands of dollars stops making sense. But that's exactly when the real work begins: months
       of small logistical and aesthetic decisions, dozens of vendor threads, none of it droppable,
       all of it living in email. A project that is high-stakes, email-centric, bounded in scope, and
-      run by first-timers is close to an ideal shape for an agent — if the couple can trust it.
+      run by first-timers is close to an ideal shape for an agent, if the couple can trust it.
     </p>
 
     <figure class="wide">
@@ -248,7 +248,7 @@
       <li>
         <strong>Low AI visibility.</strong> Juno never brands itself as "AI" or a "copilot." June is a
         wedding-planner persona; features feel like drafting, organizing, and matching. The design
-        language follows: ivory and stone surfaces, serif display type, hairline borders — a design
+        language follows: ivory and stone surfaces, serif display type, hairline borders. A design
         studio, not a SaaS dashboard with purple gradients.
       </li>
       <li>
@@ -260,22 +260,22 @@
 
     <figure class="wide">
       <img src="img/tasks.png" alt="Kanban board with five status columns and shared category filters" loading="lazy" />
-      <figcaption>The board: five statuses, drag-and-drop, one shared category taxonomy across tasks, contracts, and decisions. Note the "Needs your input" dot — a June run paused on that task, waiting for an answer.</figcaption>
+      <figcaption>The board: five statuses, drag-and-drop, one shared category taxonomy across tasks, contracts, and decisions. Note the "Needs your input" dot, where a June run paused on that task, waiting for an answer.</figcaption>
     </figure>
 
     <figure class="wide">
       <img src="img/contracts.png" alt="Contracts page showing in-review and signed vendor agreements with totals, payments made, and upcoming payment schedules" loading="lazy" />
-      <figcaption>Contracts: totals, what's paid, what's owed, and when it's due. Payment schedules answer the money questions that actually bite — a deliberate substitute for a full budgeting product (more on that below).</figcaption>
+      <figcaption>Contracts: totals, what's paid, what's owed, and when it's due. Payment schedules answer the money questions that actually bite, a deliberate substitute for a full budgeting product (more on that below).</figcaption>
     </figure>
 
     <figure class="wide">
       <img src="img/timeline.png" alt="Wedding week timeline with day-grouped agenda" loading="lazy" />
-      <figcaption>The wedding week: day-grouped agenda with side-by-side lanes for concurrent events. Times are stored as venue wall-clock — "4:30pm" means 4:30pm at the venue, no matter where you view it from.</figcaption>
+      <figcaption>The wedding week: day-grouped agenda with side-by-side lanes for concurrent events. Times are stored as venue wall-clock, so "4:30pm" means 4:30pm at the venue, no matter where you view it from.</figcaption>
     </figure>
 
     <h2>Email in, reviewed changes out</h2>
     <p>
-      The core insight: the source of truth already exists — it's just trapped in vendor email.
+      The core insight: the source of truth already exists. It's just trapped in vendor email.
       So each workspace gets its own planner email address. Forward a vendor thread (or just CC June),
       and an ingestion pipeline turns it into structured, reviewable changes:
     </p>
@@ -296,12 +296,12 @@
     <p class="flow-caption">
       The two-stage LLM pipeline (extract, then reconcile) is shared by email and uploaded documents.
       Reconcile sees the whole batch alongside existing data, so a new email can update an existing
-      proposal in place or supersede one that a newer fact made obsolete — instead of piling up duplicates.
+      proposal in place or supersede one that a newer fact made obsolete, instead of piling up duplicates.
     </p>
 
     <figure class="wide">
       <img src="img/review.png" alt="Review queue showing a vendor email thread and proposed changes with Edit, Approve and Reject buttons" loading="lazy" />
-      <figcaption>The review queue. Each vendor thread groups its proposed changes; every field is editable before approving. The pipeline never writes to the plan directly — approval does.</figcaption>
+      <figcaption>The review queue. Each vendor thread groups its proposed changes; every field is editable before approving. The pipeline never writes to the plan directly; approval does.</figcaption>
     </figure>
 
     <p>
@@ -310,13 +310,13 @@
     <ul>
       <li>
         <strong>LLM output gets a deterministic backstop.</strong> Before anything persists, a plain-code
-        filter rejects operations the model shouldn't be able to make — like a stale email walking a
+        filter rejects operations the model shouldn't be able to make, like a stale email walking a
         signed contract back to "in review," or reopening a completed task. The model proposes;
         deterministic code enforces the invariants.
       </li>
       <li>
         <strong>Email admission is deterministic, not inferred.</strong> Only a confirmed sender or an
-        already-admitted thread can get mail into the workspace — the model never decides routing.
+        already-admitted thread can get mail into the workspace. The model never decides routing.
         Everything ambiguous lands in an operator-only quarantine, invisible to the couple and to the agent.
       </li>
     </ul>
@@ -324,7 +324,7 @@
     <h2>Why June has her own inbox</h2>
     <p>
       One design decision I find most interesting: June doesn't touch the couple's email at all.
-      Each workspace gets its own inbox — a real address like <code>june-…@agentmail.to</code> —
+      Each workspace gets its own inbox, a real address like <code>june-…@agentmail.to</code>,
       that the couple forwards or CCs vendor threads to. Everything June reads arrives there; only
       mail from senders the couple has confirmed (or replies on threads June is already part of)
       gets in, and with an explicit opt-in, an approved outreach draft actually sends <em>from
@@ -339,27 +339,27 @@
       <li>
         <strong>Access should be proportional to the job.</strong> Wedding planning needs maybe a
         few dozen vendor threads; inbox access grants years of financial, medical, and personal
-        history. Asking for that much trust for that narrow a goal is bad product design — and a
+        history. Asking for that much trust for that narrow a goal is bad product design, and a
         forwarding address means the couple decides, thread by thread, what the agent ever sees.
       </li>
       <li>
-        <strong>It's OK for an AI to sound like an AI — as long as it isn't wearing your name.</strong>
+        <strong>It's OK for an AI to sound like an AI, as long as it isn't wearing your name.</strong>
         If June sends from her own address, an occasional stiff sentence or awkward choice is fine:
         everyone can see it's a third party assisting, not the couple. People already burn real
         effort making their email sound good <em>and</em> human; handing the correspondence to a
         visibly separate persona lifts that burden entirely. Sending the same words from the
-        couple's own address would put their reputation behind every sentence — which would demand
+        couple's own address would put their reputation behind every sentence, which would demand
         near-perfection from the model and forgive nothing.
       </li>
       <li>
         <strong>It mirrors how working with a real planner already works.</strong> Vendors are used
-        to "hi, I'm coordinating on behalf of the couple" — a planner with her own email address is
+        to "hi, I'm coordinating on behalf of the couple." A planner with her own email address is
         a familiar social pattern, not a new behavior anyone has to learn. That lowers the barrier
         on both sides of the conversation.
       </li>
       <li>
         <strong>It bounds the agent's context.</strong> A dedicated inbox means everything in it is,
-        by construction, wedding-relevant — no filtering a lifetime of mail to find the signal, no
+        by construction, wedding-relevant: no filtering a lifetime of mail to find the signal, no
         token budget spent on noise, and no risk of the model getting confused (or influenced) by
         unrelated correspondence. The context problem largely disappears when the mailbox itself is
         the boundary.
@@ -369,12 +369,12 @@
       This is the design decision production has validated most clearly. I expected getting vendors
       to correspond with an AI to be the awkward part; instead, they simply started replying to June
       directly, the way they would to any coordinator. The persona and the dedicated address did the
-      work — no explanation needed, no behavior to teach.
+      work: no explanation needed, no behavior to teach.
     </p>
 
     <h2>June: an agent with a structural firewall</h2>
     <p>
-      Every chat conversation — a quick question, or "handle this task for me" — runs on one
+      Every chat conversation, a quick question or "handle this task for me," runs on one
       background engine. June can read the whole workspace, read ingested email and parsed documents,
       and search the web. When she needs something from you, the run <em>pauses</em>: a question,
       an email draft, or a proposed workspace change becomes a card in the conversation, and the run
@@ -383,15 +383,15 @@
 
     <figure class="wide">
       <img src="img/chat-write.png" alt="Chat with June showing an answered question, an outreach email draft, a steering reply, and a proposed workspace change awaiting approval" loading="lazy" />
-      <figcaption>One June run on a task: she asks about budget, drafts vendor outreach, and proposes a follow-up task — each a gate the couple explicitly clears. The reply box doubles as the approval surface: "Looks great — go ahead" resumes the run.</figcaption>
+      <figcaption>One June run on a task: she asks about budget, drafts vendor outreach, and proposes a follow-up task, each a gate the couple explicitly clears. The reply box doubles as the approval surface: "Looks great, go ahead" resumes the run.</figcaption>
     </figure>
 
     <p>
       The safety model is the part I'd defend in any design review:
       <strong>the capability firewall is structural, not prompted.</strong> There is no send-email tool
-      and no payment tool anywhere in the agent's tool registry — not "the prompt says don't,"
-      but <em>the capability does not exist</em>. The workspace has 70 server actions; only 57 are
-      registered as agent tools, and the gap is deliberate — sends, uploads, invites, and review-queue
+      and no payment tool anywhere in the agent's tool registry. It isn't "the prompt says don't,"
+      it's that <em>the capability does not exist</em>. The workspace has 70 server actions; only 57 are
+      registered as agent tools, and the gap is deliberate: sends, uploads, invites, and review-queue
       approvals are user-only. Sending an approved email happens as a <em>user</em> action at the
       approval seam (idempotent via a unique per-draft send claim, so double-clicking Approve can't
       double-send). A unit test pins the allowlist so a future refactor can't quietly hand the model
@@ -403,7 +403,7 @@
     <ul>
       <li>
         <strong>Conversations survive runs.</strong> A follow-up message carries the previous run's full
-        transcript forward — tool results, drafts, approvals — with dangling tool-calls repaired and a
+        transcript forward (tool results, drafts, approvals) with dangling tool-calls repaired and a
         character-budget trim that blanks old tool results without breaking the transcript structure.
         June remembers what she found; she doesn't start over.
       </li>
@@ -423,7 +423,7 @@
       A month of solo scope means saying no to things that would appear in any competitor's feature
       matrix. The clearest cut was <strong>budget tracking</strong>. Every wedding tool has a budget
       module; I skipped it. Contract payment schedules already answer the money questions that
-      actually bite — what's owed, to whom, by when — as a side effect of data the pipeline extracts
+      actually bite (what's owed, to whom, by when) as a side effect of data the pipeline extracts
       anyway. A full budgeting product (envelopes, forecasts, category rollups) is a different
       product, and building a mediocre version of it would have taken weeks away from the thing only
       Juno does: turning vendor email into a plan you can trust. Depth on the coordination loop beat
@@ -432,17 +432,17 @@
 
     <h2>Running my own wedding on it</h2>
     <p>
-      Juno isn't a demo I built and moved on from — it's how my wedding is actually being planned.
+      Juno isn't a demo I built and moved on from. It's how my wedding is actually being planned.
       Every vendor thread now includes June. At any given time the board holds roughly thirty live
       tasks in equal thirds: about ten in the backlog, ten waiting on us, and ten waiting on vendors.
-      The couple-side work is executing on a vision — a stream of logistical and aesthetic decisions —
+      The couple-side work is executing on a vision, a stream of logistical and aesthetic decisions,
       and keeping track of all of it is exactly the job Juno was built for.
     </p>
     <p>
       How do I know if it's working? The metric I watch is <strong>tasks completed by June, and how
       many days a task sits in progress</strong>. So much of a wedding is locking in details sooner:
       every early decision returns time to the couple and surfaces downstream risks while they're
-      still cheap. And the metric is honest by construction — nothing forces a couple to route work
+      still cheap. And the metric is honest by construction: nothing forces a couple to route work
       through June. They can complete any task themselves, so if June is completing tasks, it's
       because she earned them.
     </p>
@@ -452,18 +452,17 @@
     <ul>
       <li>
         <strong>The hardest model problem is editorial, not extractive.</strong> June's biggest
-        struggle isn't parsing a payment schedule out of an email — it's judging which of the
+        struggle isn't parsing a payment schedule out of an email. It's judging which of the
         hundred small facts flowing past is a <em>decision worth logging</em> and making visible.
         I couldn't define that judgment in a vacuum, and neither could an eval suite written ahead
         of time. So the eval dataset grows from real life: when June gets it wrong, I flag the run
-        in the UI and it becomes a test case. <a href="evals/">How that pipeline works — and why the
-        bad output must never become the expected answer — gets its own article.</a>
+        in the UI and it becomes a test case.
       </li>
       <li>
         <strong>Agent costs compound quietly.</strong> I started on Claude Sonnet and Opus with a
         deliberate bias: get the product <em>functional</em> as fast as possible, optimize spend
         later. Later arrived quickly. I've since introduced a model router so I can experiment with
-        different models per task — routing cheap, structured work away from frontier models without
+        different models per task, routing cheap, structured work away from frontier models without
         touching the surfaces where judgment matters. That's a future article of its own.
       </li>
     </ul>
@@ -472,8 +471,8 @@
     <p>
       An agent product lives or dies on quality you can't see in a demo: does the extraction pipeline
       catch the payment schedule buried in an email? Does June answer from the workspace's actual
-      data, or does she make something up? Both LLM surfaces have eval harnesses — 22 golden fixtures
-      for the ingestion pipeline, 21 scenario fixtures across 7 suites for the agent — built on a few
+      data, or does she make something up? Both LLM surfaces have eval harnesses (22 golden fixtures
+      for the ingestion pipeline, 21 scenario fixtures across 7 suites for the agent) built on a few
       opinionated principles: evaluate the production code path rather than a copy of it, score
       deterministically first and use an LLM judge only for the genuinely fuzzy residue, diff every
       run against a committed baseline instead of gaming a pass/fail threshold, and keep evals
@@ -483,10 +482,10 @@
 
     <h2>How it was built</h2>
     <p>
-      Juno is a solo project, built in about a month alongside actually planning the wedding — and
+      Juno is a solo project, built in about a month alongside actually planning the wedding, and
       it's also my testbed for AI-native development. I ran a spec-driven workflow with AI coding
-      agents (Claude Code and Codex): each feature goes roadmap → written spec → implementation plan →
-      task list → implementation, with the repo's conventions and invariants maintained in an
+      agents (Claude Code and Codex): each feature goes roadmap → spec → plan → task list →
+      implementation, with the repo's conventions and invariants maintained in an
       agents-facing architecture document that keeps every session grounded. Four quality gates
       (lint, typecheck, unit tests, production build) plus a 36-test Playwright e2e suite against
       real auth and RLS run on every PR. What worked, what broke, and what it taught me about

--- a/juno/index.html
+++ b/juno/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Juno — an AI wedding planner | Jaeyoon Jung</title>
-  <meta name="description" content="How I built Juno, an AI-agent wedding planning studio: product thinking, agent architecture, and the trust boundaries that make an AI agent safe to use." />
+  <meta name="description" content="How I built Juno, an AI-agent wedding planning studio, solo in about a month — and now run my own wedding on it. A case study in the trust boundaries that make an AI agent safe to use." />
   <style>
     :root {
       --text: #1a1a1a;
@@ -59,6 +59,12 @@
     }
 
     .meta {
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-bottom: 12px;
+    }
+
+    .series {
       color: var(--muted);
       font-size: 0.85rem;
       margin-bottom: 48px;
@@ -175,6 +181,7 @@
       padding-top: 24px;
       border-top: 1px solid var(--border);
       display: flex;
+      flex-wrap: wrap;
       gap: 20px;
       font-size: 0.95rem;
     }
@@ -199,8 +206,9 @@
     <a class="back" href="/">← Jaeyoon Jung</a>
 
     <h1>Juno: an AI wedding planner you can actually trust</h1>
-    <p class="subtitle">A solo-built, production-deployed AI agent product — and a case study in designing the trust boundaries that make an agent safe to hand real work to.</p>
+    <p class="subtitle">An AI-agent product I built solo in about a month — and now use to run my own wedding. A case study in designing the trust boundaries that make an agent safe to hand real work to.</p>
     <p class="meta">2026 · <a href="https://getjuno.tech/" target="_blank" rel="noopener">getjuno.tech</a> · Next.js, Postgres, Claude</p>
+    <p class="series">Deep dives: <a href="evals/">Evals instead of vibes</a> · <a href="building/">Building Juno with AI coding agents</a></p>
 
     <p>
       While planning my own wedding, I kept hitting the same three problems every couple hits:
@@ -209,10 +217,20 @@
       <strong>you've never done this before</strong> — you plan a wedding exactly once, with no way to know if you've covered everything.
     </p>
     <p>
-      Juno is my answer: a private planning studio for one couple, with an experienced-planner agent
-      — <strong>June</strong> — working behind it. You forward vendor emails to her, upload contracts and
+      Juno is my answer. Two names, one letter apart, so let me be precise:
+      <strong>Juno</strong> is the product — a private planning studio for one couple.
+      <strong>June</strong> is the planner who works inside it — an agent with her own inbox, her own
+      voice, and deliberately limited powers. You forward vendor emails to June, upload contracts and
       proposals, and ask her to handle things. She reads everything, keeps the workspace current, and
       drafts outreach — but <em>every</em> change to your plan passes through your explicit approval.
+    </p>
+    <p>
+      The wedge is specific, because I lived it. We locked in the big, obvious vendor decisions —
+      venue, caterer, photographer, florals — ourselves. At that point, hiring a human planner for
+      thousands of dollars stops making sense. But that's exactly when the real work begins: months
+      of small logistical and aesthetic decisions, dozens of vendor threads, none of it droppable,
+      all of it living in email. A project that is high-stakes, email-centric, bounded in scope, and
+      run by first-timers is close to an ideal shape for an agent — if the couple can trust it.
     </p>
 
     <figure class="wide">
@@ -243,6 +261,11 @@
     <figure class="wide">
       <img src="img/tasks.png" alt="Kanban board with five status columns and shared category filters" loading="lazy" />
       <figcaption>The board: five statuses, drag-and-drop, one shared category taxonomy across tasks, contracts, and decisions. Note the "Needs your input" dot — a June run paused on that task, waiting for an answer.</figcaption>
+    </figure>
+
+    <figure class="wide">
+      <img src="img/contracts.png" alt="Contracts page showing in-review and signed vendor agreements with totals, payments made, and upcoming payment schedules" loading="lazy" />
+      <figcaption>Contracts: totals, what's paid, what's owed, and when it's due. Payment schedules answer the money questions that actually bite — a deliberate substitute for a full budgeting product (more on that below).</figcaption>
     </figure>
 
     <figure class="wide">
@@ -342,6 +365,12 @@
         the boundary.
       </li>
     </ul>
+    <p>
+      This is the design decision production has validated most clearly. I expected getting vendors
+      to correspond with an AI to be the awkward part; instead, they simply started replying to June
+      directly, the way they would to any coordinator. The persona and the dedicated address did the
+      work — no explanation needed, no behavior to teach.
+    </p>
 
     <h2>June: an agent with a structural firewall</h2>
     <p>
@@ -361,10 +390,12 @@
       The safety model is the part I'd defend in any design review:
       <strong>the capability firewall is structural, not prompted.</strong> There is no send-email tool
       and no payment tool anywhere in the agent's tool registry — not "the prompt says don't,"
-      but <em>the capability does not exist</em>. Sending an approved email happens as a
-      <em>user</em> action at the approval seam (idempotent via a unique per-draft send claim, so
-      double-clicking Approve can't double-send). A unit test pins the allowlist so a future refactor
-      can't quietly hand the model send authority.
+      but <em>the capability does not exist</em>. The workspace has 70 server actions; only 57 are
+      registered as agent tools, and the gap is deliberate — sends, uploads, invites, and review-queue
+      approvals are user-only. Sending an approved email happens as a <em>user</em> action at the
+      approval seam (idempotent via a unique per-draft send claim, so double-clicking Approve can't
+      double-send). A unit test pins the allowlist so a future refactor can't quietly hand the model
+      send authority.
     </p>
     <p>
       A few more agent-engineering details under the hood:
@@ -387,74 +418,85 @@
       </li>
     </ul>
 
+    <h2>What I cut</h2>
+    <p>
+      A month of solo scope means saying no to things that would appear in any competitor's feature
+      matrix. The clearest cut was <strong>budget tracking</strong>. Every wedding tool has a budget
+      module; I skipped it. Contract payment schedules already answer the money questions that
+      actually bite — what's owed, to whom, by when — as a side effect of data the pipeline extracts
+      anyway. A full budgeting product (envelopes, forecasts, category rollups) is a different
+      product, and building a mediocre version of it would have taken weeks away from the thing only
+      Juno does: turning vendor email into a plan you can trust. Depth on the coordination loop beat
+      breadth on the checklist.
+    </p>
+
+    <h2>Running my own wedding on it</h2>
+    <p>
+      Juno isn't a demo I built and moved on from — it's how my wedding is actually being planned.
+      Every vendor thread now includes June. At any given time the board holds roughly thirty live
+      tasks in equal thirds: about ten in the backlog, ten waiting on us, and ten waiting on vendors.
+      The couple-side work is executing on a vision — a stream of logistical and aesthetic decisions —
+      and keeping track of all of it is exactly the job Juno was built for.
+    </p>
+    <p>
+      How do I know if it's working? The metric I watch is <strong>tasks completed by June, and how
+      many days a task sits in progress</strong>. So much of a wedding is locking in details sooner:
+      every early decision returns time to the couple and surfaces downstream risks while they're
+      still cheap. And the metric is honest by construction — nothing forces a couple to route work
+      through June. They can complete any task themselves, so if June is completing tasks, it's
+      because she earned them.
+    </p>
+    <p>
+      Two lessons from production that no amount of building in private would have taught me:
+    </p>
+    <ul>
+      <li>
+        <strong>The hardest model problem is editorial, not extractive.</strong> June's biggest
+        struggle isn't parsing a payment schedule out of an email — it's judging which of the
+        hundred small facts flowing past is a <em>decision worth logging</em> and making visible.
+        I couldn't define that judgment in a vacuum, and neither could an eval suite written ahead
+        of time. So the eval dataset grows from real life: when June gets it wrong, I flag the run
+        in the UI and it becomes a test case. <a href="evals/">How that pipeline works — and why the
+        bad output must never become the expected answer — gets its own article.</a>
+      </li>
+      <li>
+        <strong>Agent costs compound quietly.</strong> I started on Claude Sonnet and Opus with a
+        deliberate bias: get the product <em>functional</em> as fast as possible, optimize spend
+        later. Later arrived quickly. I've since introduced a model router so I can experiment with
+        different models per task — routing cheap, structured work away from frontier models without
+        touching the surfaces where judgment matters. That's a future article of its own.
+      </li>
+    </ul>
+
     <h2>Evals instead of vibes</h2>
     <p>
       An agent product lives or dies on quality you can't see in a demo: does the extraction pipeline
       catch the payment schedule buried in an email? Does June answer from the workspace's actual
-      data, or does she make something up? Early on I was judging prompt changes by re-running a few
-      scenarios and eyeballing the output — which stops working the moment you have more than a
-      handful of behaviors to protect. So I built eval harnesses for both LLM surfaces (the ingestion
-      pipeline and the agent), and the design decisions there are some of the ones I'd defend hardest.
+      data, or does she make something up? Both LLM surfaces have eval harnesses — 22 golden fixtures
+      for the ingestion pipeline, 21 scenario fixtures across 7 suites for the agent — built on a few
+      opinionated principles: evaluate the production code path rather than a copy of it, score
+      deterministically first and use an LLM judge only for the genuinely fuzzy residue, diff every
+      run against a committed baseline instead of gaming a pass/fail threshold, and keep evals
+      deliberately separate from CI. The full reasoning is in
+      <a href="evals/">Evals instead of vibes</a>.
     </p>
-    <ul>
-      <li>
-        <strong>Evaluate the production code path, not a copy of it.</strong> The harnesses run the
-        real extraction and reconcile functions, and the real agent loop — with database-backed tools
-        swapped for fixture-backed ones that serve identical schemas from a workspace snapshot. The
-        tradeoff is more plumbing up front, but the alternative (a simplified "eval version" of the
-        pipeline) silently drifts from what production actually does, and then your scores measure
-        nothing.
-      </li>
-      <li>
-        <strong>Deterministic scoring first; an LLM judge only where determinism fails.</strong>
-        Most of what matters is checkable in plain code: did the right entities come out, with the
-        right key fields, the right statuses, the right tool calls made — and the forbidden ones not
-        made. An LLM judge is reserved for the genuinely fuzzy residue: is "Confirm final headcount
-        with caterer" the same task as "caterer needs guest count"? Is an answer actually supported
-        by what the tools returned? Judges are convenient, so the temptation is to let one grade
-        everything — but a judge is itself a model that drifts and has blind spots. Keeping its
-        scope narrow keeps the scores auditable: when a metric moves, I can almost always point to
-        the exact deterministic check that moved it.
-      </li>
-      <li>
-        <strong>A committed baseline instead of pass/fail thresholds.</strong> Absolute thresholds
-        ("extraction accuracy must exceed 90%") invite gaming and hide slow decay. Instead, every
-        eval run diffs against a baseline file checked into the repo, and updating that baseline is
-        an explicit, reviewable commit. A prompt change that trades recall on contracts for precision
-        on tasks shows up as exactly that — a diff a reviewer can reason about, not a green checkmark.
-      </li>
-      <li>
-        <strong>Evals are not CI.</strong> Eval runs call the real model APIs: they cost money and
-        are nondeterministic, which makes them terrible PR gates. So the two systems are deliberately
-        separate — CI exercises every user-facing flow end-to-end against deterministic mock model
-        responses (does the machinery work?), while evals run on demand with repeat trials to
-        average out variance (is the model's judgment good?). Conflating the two gets you flaky CI
-        and eval suites nobody runs.
-      </li>
-      <li>
-        <strong>Test cases come from production failures, carefully.</strong> When June gets
-        something wrong, I can flag the run in the UI, which snapshots everything the failing run
-        saw — the conversation, and the workspace state <em>at that moment</em>, so the case still
-        reproduces after the live data moves on. Two guardrails I added after thinking about how
-        this could go wrong: the flagged (bad) output is preserved as reference but never becomes
-        the expected answer — a human writes what <em>should</em> have happened, otherwise the suite
-        would enshrine the failure it was meant to catch — and every case passes through human
-        review and redaction before promotion, because production data contains real names, vendors,
-        and money.
-      </li>
-    </ul>
 
     <h2>How it was built</h2>
     <p>
-      Juno is a solo project, built in roughly two months alongside actually planning the wedding —
-      and it's also my testbed for AI-native development. I ran a spec-driven workflow with AI coding
-      agents: each feature goes roadmap → written spec → implementation plan → task list → implementation,
-      with the repo's conventions and invariants maintained in an agents-facing architecture document
-      that keeps every session grounded. Four quality gates (lint, typecheck, unit tests, production
-      build) plus a Playwright e2e suite against real auth and RLS run on every PR.
+      Juno is a solo project, built in about a month alongside actually planning the wedding — and
+      it's also my testbed for AI-native development. I ran a spec-driven workflow with AI coding
+      agents (Claude Code and Codex): each feature goes roadmap → written spec → implementation plan →
+      task list → implementation, with the repo's conventions and invariants maintained in an
+      agents-facing architecture document that keeps every session grounded. Four quality gates
+      (lint, typecheck, unit tests, production build) plus a 36-test Playwright e2e suite against
+      real auth and RLS run on every PR. What worked, what broke, and what it taught me about
+      building with agent teams is in <a href="building/">its own write-up</a>.
     </p>
+
     <div class="footer-links">
       <a href="https://getjuno.tech/" target="_blank" rel="noopener">Try Juno</a>
+      <a href="evals/">Evals instead of vibes</a>
+      <a href="building/">Building Juno with AI coding agents</a>
       <a href="/">About me</a>
       <a href="mailto:jaeyoonjung95@gmail.com">Email</a>
     </div>


### PR DESCRIPTION
## Summary
- Remove the dangling "How that pipeline works ... gets its own article" reference from the case study; its link target didn't deliver on the promise
- Ground the evals article in how the harnesses actually work in the wedding-planner repo: real extract/reconcile functions and real agent loop with fixture-backed read tools, deterministic scoring with a deliberately narrow LLM judge, per-harness committed baselines behind an update flag, evals kept out of npm test and CI, and the flag-to-draft-fixture loop where flagged output never seeds the expected answer
- Ground the building article in the actual spec-driven skills: roadmap item -> spec.md -> plan.md -> tasks.md -> implementation -> PR, each artifact a human-approved gate, with AGENTS.md/CLAUDE.md named as the agents-facing context doc and the 3-8 task granularity floor
- Credit Addy Osmani's "How to write a good spec for AI agents" as the source of the spec-writing approach
- Remove every em dash across all three articles in favor of plainer punctuation

## Test plan
- [ ] Open /juno/, /juno/evals/, /juno/building/ and confirm they render correctly in light and dark mode
- [ ] Confirm no em dashes remain in the three articles
- [ ] Click every internal link (series links, footers, back links) and confirm they resolve
- [ ] Click the Addy Osmani link and confirm it reaches the article
- [ ] Read the evals article against the wedding-planner repo and confirm the harness description matches